### PR TITLE
Edit rescale

### DIFF
--- a/src/chaosdetection/lyapunovs.jl
+++ b/src/chaosdetection/lyapunovs.jl
@@ -328,29 +328,10 @@ function λdist(integ::AbstractODEIntegrator{Alg, IIP, Vector{S}}) where {Alg, I
 end
 
 # Rescales:
-function rescale!(integ::MinimalDiscreteIntegrator{true, Vector{S}}, a) where {S<:SVector}
-    integ.u[2] = integ.u[1] + (integ.u[2] - integ.u[1])/a
-    u_modified!(integ, true)
+function rescale!(integ,a)
+    r = get_state(integ,1) + (get_state(integ,2)-get_state(integ,1))./a
+    set_state!(integ,r,2)
 end
-function rescale!(integ::MinimalDiscreteIntegrator{true, Vector{S}}, a) where {S<:Vector}
-    @. integ.u[2] = integ.u[1] + (integ.u[2] - integ.u[1])/a
-    u_modified!(integ, true)
-end
-function rescale!(integ::AbstractODEIntegrator{Alg, IIP, M}, a) where {Alg, IIP, M<:Matrix}
-    for i in 1:size(integ.u)[1]
-        integ.u[i, 2] = integ.u[i,1] + (integ.u[i,2] - integ.u[i,1])/a
-    end
-    u_modified!(integ, true)
-end
-function rescale!(integ::AbstractODEIntegrator{Alg, IIP, Vector{S}}, a) where {Alg, IIP, S<:Vector}
-    @. integ.u[2] = integ.u[1] + (integ.u[2] - integ.u[1])/a
-    u_modified!(integ, true)
-end
-function rescale!(integ::AbstractODEIntegrator{Alg, IIP, Vector{S}}, a) where {Alg, IIP, S<:SVector}
-    integ.u[2] = integ.u[1] + (integ.u[2] - integ.u[1])/a
-    u_modified!(integ, true)
-end
-
 
 
 #####################################################################################

--- a/test/chaosdetection/lyapunov_exponents.jl
+++ b/test/chaosdetection/lyapunov_exponents.jl
@@ -96,7 +96,7 @@ end
     @test isapprox(λ1, log(0.9); rtol = 1e-4)
     ds = DiscreteDynamicalSystem(g, rand(3), nothing)
     λ2 = lyapunov(ds, 100000)
-    @test isapprox(λ1, log(0.9); rtol = 1e-4)
+    @test isapprox(λ2, log(0.9); rtol = 1e-4)
 end
 
 @testset "Lyapunov convergence" begin


### PR DESCRIPTION
Preallocated implementation of `rescale!` using `get_state` and `set_state`.
Also corrected a typo in test/chaos_detection/lyapunov_exponents.jl on line 99 where λ1 was used instead of λ2 in the testcase.